### PR TITLE
chore: remplace les métadonnées du template starter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,4 +38,5 @@ Membership uses an embedded HelloAsso iframe widget (`#haWidget`) — the head p
 ## Conventions
 
 - Keep ARIA labels, semantic sectioning, and keyboard-reachable nav intact — the site was built with accessibility in mind.
-- The README is the upstream starter template's (`vite-tailwind-nojs-starter`), not this project's — ignore it.
+- `pnpm run format` needs `.prettierrc` to point `tailwindStylesheet` at `src/style.css`. Without it the Tailwind plugin falls back to v3 mode, hunts for a nonexistent `tailwind.config.mjs`, and the script fails.
+- `LICENSE` is the upstream starter's MIT (Kometo Labs) — the project was scaffolded from `vite-tailwind-nojs-starter`. Leave it alone.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# Vite TailwindCSS NoJS Starter
+# St-Martin joue
 
-Scaffold a new project with Vite and Tailwind CSS preconfigured with ease.
+Site de l'association **St-Martin joue**, club de jeux de société à
+Saint-Martin-de-l'If (Seine-Maritime). En ligne sur
+[stmartinjoue.fr](https://stmartinjoue.fr/).
 
-## Motivation
+Page unique en HTML/CSS, construite avec Vite et Tailwind CSS v4. Pas de
+framework JS : `src/main.js` ne contient que le menu mobile et le calcul de la
+prochaine soirée.
 
-Most existing Vite + Tailwind starters are aimed to work with a JS framework, e.g Vue or React.
-An important difference of this starter template is that **the build stage does not involve any JavaScript, just pure HTML/CSS compilation**.
-
-## When to use
-
-1. When you need to develop a pure HTML/CSS prototype.
-2. When you import a standalone version of a JS framework right from HTML.
-
-## How to use
+## Développement
 
 ```bash
-npx degit kometolabs/vite-tailwind-nojs-starter my-tailwind-app
-cd my-tailwind-app
-pnpm i || yarn || npm i
-pnpm run dev || yarn dev || npm run dev
+pnpm install
+pnpm run dev      # serveur local sur http://localhost:5173/index.html
+pnpm run build    # build de production dans ./dist
+pnpm run preview  # sert le build de production
+pnpm run format   # Prettier + tri des classes Tailwind
 ```
 
-**Happy coding!**
+## Déploiement
+
+Chaque push sur `main` déclenche `.github/workflows/deploy.yml`, qui build et
+publie `dist/` sur GitHub Pages. Il n'y a pas d'environnement de préproduction :
+une fusion dans `main` part directement en production.
+
+## Structure
+
+| Fichier | Rôle |
+|---|---|
+| `src/index.html` | tout le contenu du site, découpé en sections ancrées |
+| `src/main.js` | menu mobile, calcul de la prochaine soirée |
+| `src/style.css` | thème Tailwind v4 (`@theme`), animations et classes maison |
+| `src/public/img/` | images et favicon, servis à la racine du site |
+
+## Licence
+
+Le code est parti du template
+[vite-tailwind-nojs-starter](https://github.com/kometolabs/vite-tailwind-nojs-starter)
+de Kometo Labs, sous licence MIT (voir `LICENSE`).

--- a/package.json
+++ b/package.json
@@ -1,19 +1,13 @@
 {
-  "name": "vite-tailwind-starter",
-  "description": "NoJS Vite + Tailwind CSS Starter",
+  "name": "stmartinjoue",
+  "description": "Site de St-Martin joue, association de jeux de société à Saint-Martin-de-l'If",
   "version": "0.0.0",
-  "keywords": [
-    "template",
-    "scaffold",
-    "tailwind",
-    "tailwindcss",
-    "tailwind-css",
-    "vite",
-    "vitejs",
-    "vite-template",
-    "vitejs-template",
-    "vite-tailwind"
-  ],
+  "private": true,
+  "homepage": "https://stmartinjoue.fr/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dnj855/stmartinjoue.git"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Le dépôt portait encore l'identité de `vite-tailwind-nojs-starter`, le template dont il est parti.

## package.json

- `name` : `vite-tailwind-starter` → `stmartinjoue`
- `description` : celle du template → celle du site
- `keywords` : supprimés (`template`, `scaffold`, `vite-template`… — c'était le référencement npm du starter, sans objet ici)
- ajout de `"private": true` — le paquet n'a pas vocation à être publié, et ça bloque un `npm publish` accidentel
- ajout de `homepage` et `repository`

Scripts et dépendances inchangés.

## README.md

Réécrit pour ce projet : commandes, déploiement GitHub Pages, tableau de structure des fichiers. L'ancien expliquait comment scaffolder un nouveau projet avec `degit`.

## Ce que je n'ai pas touché

`LICENSE` reste la MIT de Kometo Labs. Le code vient bien de leur starter, retirer leur copyright unilatéralement n'est pas à moi de le décider. Le README y renvoie explicitement.

## Vérification

`NODE_ENV=production pnpm run build` passe, hashes d'assets identiques à `main` (`index-Dqf9aSmE.css`, `index-DheoMBaH.js`) — ces changements sont purement déclaratifs, le site produit est bit-à-bit le même.

🤖 Generated with [Claude Code](https://claude.com/claude-code)